### PR TITLE
Typo in Mustache template

### DIFF
--- a/src/main/resources/com/bluetrainsoftware/maven/jaxrs2typescript/api.mustache
+++ b/src/main/resources/com/bluetrainsoftware/maven/jaxrs2typescript/api.mustache
@@ -102,9 +102,9 @@ export class {{name}}Impl implements {{name}} {
             headers: headerParams,
             uri: localVarPath,
             json: true,
-{{#bodyParam}}
+{{#bodyParams}}
             body: {{name}},
-{{/bodyParam}}
+{{/bodyParams}}
         };
 
         if (accessToken !== undefined) {


### PR DESCRIPTION
bodyParam doesn't match method getBodyParams() in RestMethod
